### PR TITLE
Inflection-70 Improve the reading performance of dictionary-parser

### DIFF
--- a/inflection/tools/dictionary-parser/README.md
+++ b/inflection/tools/dictionary-parser/README.md
@@ -9,7 +9,7 @@ These tools generate files that describes the grammatical properties of words fr
 ## Usage for Wikidata
 
 1) Download a copy of Wikidata from https://dumps.wikimedia.org/wikidatawiki/entities/ (e.g. https://dumps.wikimedia.org/wikidatawiki/entities/20250115/wikidata-20250115-lexemes.json.bz2)
-2) Optionally decompress the file for improved reading performance.
+2) Optionally decompress the file. This tool runs faster if it's decompressed.
 3) Check what options were used for your language. They are at the end of the generated dictionary_XX.lst, look for "generated with options"
    - Run `grep 'generated with options' ../../resources/org/unicode/inflection/dictionary/dictionary_XX.lst | cut -d':' -f2`
    - If the above command prints nothing, no additional options were used to generate the file, or it was generated with a different tool.
@@ -20,5 +20,5 @@ These tools generate files that describes the grammatical properties of words fr
     ./ParseWikidata <THE_OPTIONS_FROM_STEP_3> \
     --inflections ../../resources/org/unicode/inflection/dictionary/inflectional_XX.xml \
     --dictionary ../../resources/org/unicode/inflection/dictionary/dictionary_XX.lst \
-    <wikidata-NNNNNNNN-lexemes.json>
+    <wikidata-NNNNNNNN-lexemes.json[.bz2]>
 ```

--- a/inflection/tools/dictionary-parser/README.md
+++ b/inflection/tools/dictionary-parser/README.md
@@ -9,15 +9,16 @@ These tools generate files that describes the grammatical properties of words fr
 ## Usage for Wikidata
 
 1) Download a copy of Wikidata from https://dumps.wikimedia.org/wikidatawiki/entities/ (e.g. https://dumps.wikimedia.org/wikidatawiki/entities/20250115/wikidata-20250115-lexemes.json.bz2)
-2) Check what options were used for your language. They are at the end of the generated dictionary_XX.lst, look for "generated with options"
+2) Optionally decompress the file for improved reading performance.
+3) Check what options were used for your language. They are at the end of the generated dictionary_XX.lst, look for "generated with options"
    - Run `grep 'generated with options' ../../resources/org/unicode/inflection/dictionary/dictionary_XX.lst | cut -d':' -f2`
    - If the above command prints nothing, no additional options were used to generate the file, or it was generated with a different tool.
    - To see what options are available run `./ParseWikidata`
    - At minimum use the `--locale` option to specify the ISO-639 code for the language to extract.
-3) Run
+4) Run
 ```
-    ./ParseWikidata <THE_OPTIONS_FROM_STEP_2> \
+    ./ParseWikidata <THE_OPTIONS_FROM_STEP_3> \
     --inflections ../../resources/org/unicode/inflection/dictionary/inflectional_XX.xml \
     --dictionary ../../resources/org/unicode/inflection/dictionary/dictionary_XX.lst \
-    <wikidata-NNNNNNNN-lexemes.json.bz2>
+    <wikidata-NNNNNNNN-lexemes.json>
 ```

--- a/inflection/tools/dictionary-parser/src/main/java/org/unicode/wikidata/ClaimsJsonDeserializer.java
+++ b/inflection/tools/dictionary-parser/src/main/java/org/unicode/wikidata/ClaimsJsonDeserializer.java
@@ -25,7 +25,8 @@ public class ClaimsJsonDeserializer extends JsonDeserializer<Map<String, List<St
         var nodeItr = node.fields();
         while (nodeItr.hasNext()) {
             var claimsItr = nodeItr.next();
-            if (!ParseWikidata.IMPORTANT_PROPERTIES.contains(claimsItr.getKey())) {
+            var claimKey = claimsItr.getKey();
+            if (!ParseWikidata.IMPORTANT_PROPERTIES.contains(claimKey)) {
                 continue;
             }
             var claimItr = claimsItr.getValue().iterator();
@@ -53,11 +54,11 @@ public class ClaimsJsonDeserializer extends JsonDeserializer<Map<String, List<St
                         }
                     }
                 }
-                if (array != null) {
+                if (array != null && !array.isEmpty()) {
                     if (result == null) {
                         result = new TreeMap<>();
                     }
-                    result.put(claimsItr.getKey(), array);
+                    result.put(claimKey, array);
                 }
             }
         }

--- a/inflection/tools/dictionary-parser/src/main/java/org/unicode/wikidata/Lexeme.java
+++ b/inflection/tools/dictionary-parser/src/main/java/org/unicode/wikidata/Lexeme.java
@@ -14,7 +14,6 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Lexeme {
-    public String type;
     public String id;
     public Map<String, LexemeRepresentation> lemmas;
     public String lexicalCategory;


### PR DESCRIPTION
Resolves #70

It was uncovered that the reading performance of the dictionary-parser can be improved by adjusting how the file is read. Reading from a bzip2 file went from about 6 minutes on my computer to about 1 minute and 40 seconds by adjusting the buffering. It goes down to about 20 seconds for reading from the json file directly.

About 95% of the remaining 20 seconds is still just in the deserialization process, but I struggle to understand how to improve that performance. Perhaps conditionally parsing the structures based on the languages in the lemmas might help a little bit, but that can be investigated at a future time.