### PR TITLE
Added the support for macos

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -26,12 +26,16 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         build_type: [Release]
         c_compiler: [clang]
         # All [OS x compiler] items should be covered in include/exclude sections.
         include:
           - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+
+          - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
 
@@ -47,6 +51,17 @@ jobs:
       run: |
         echo "project-root-dir=${{ github.workspace }}/inflection" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=${{ github.workspace }}/inflection/build" >> "$GITHUB_OUTPUT"
+  
+      # Install all the required dependencies for the macos
+    - name: Install ICU (Ubuntu/macos)
+      run: |
+        if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          sudo apt-get update && sudo apt-get install -y libicu-dev icu-devtools
+          echo "ICU_ROOT=/usr" >> $GITHUB_ENV
+        elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            brew list icu4c || brew install icu4c
+            echo "ICU_ROOT=$(brew --prefix icu4c)" >> $GITHUB_ENV
+        fi
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
Hello @nciric , 

I have added support for macOS. While installing ICU for macOS, I encountered a warning that can sometimes be distracting:

icu4c@76 76.1_1 is already installed and up-to-date. To reinstall 76.1_1, run: brew reinstall icu4c@76.

To resolve this issue, I added a condition that first checks if ICU is already installed. If it is, the installation step is skipped, and the process moves to the next step.

``` bash
brew list icu4c || brew install icu4c
```

![Screenshot 2025-03-10 234608](https://github.com/user-attachments/assets/6eb63cb2-4672-4aee-87d2-6c1c28cd0c60)


Please review the macOS support I’ve added, and let me know if any changes are needed.