### PR TITLE
Create distribution packages for ubuntu (.deb release v0.0.1)

### DIFF
--- a/.github/workflows/create-ubuntu-distribution-packaging.yml
+++ b/.github/workflows/create-ubuntu-distribution-packaging.yml
@@ -1,3 +1,12 @@
+# ----------------------------------------------------------------------------------------
+# To update ICU version:
+# 1. Update the ICU_VERSION environment variable below.
+# 2. Check the ICU binary URL — is the filename still Ubuntu22.04-x64.tgz?
+#    (e.g., icu4c-78_1-Ubuntu22.04-x64.tgz)
+# 3. Update inflection/CMakeLists.txt:
+#    - Modify `CPACK_DEBIAN_PACKAGE_DEPENDS` to match the new ICU version.
+# ----------------------------------------------------------------------------------------
+
 name: Build & Package (Ubuntu)
 
 on:

--- a/inflection/CMakeLists.txt
+++ b/inflection/CMakeLists.txt
@@ -136,8 +136,10 @@ install(DIRECTORY ${INFLECTION_DATA_ROOT}/    TYPE DATA    COMPONENT inflection_
 # CPack Configuration for Ubuntu Packaging
 
 set(CPACK_PACKAGE_NAME "unicode-inflection")
-set(CPACK_PACKAGE_VERSION "${INFLECTION_VERSION}")
 
+# Apply the current tagged Inflection version to the CPack version.
+# CPack may inherit a default or cached version, so we explicitly set it here.
+set(CPACK_PACKAGE_VERSION "${INFLECTION_VERSION}")
 
 string(REPLACE "." ";" INFLECTION_VERSION_LIST "${INFLECTION_VERSION}")
 
@@ -156,8 +158,6 @@ endif()
 if(_len GREATER 2)
   list(GET INFLECTION_VERSION_LIST 2 CPACK_PACKAGE_VERSION_PATCH)
 endif()
-
-
 
 set(CPACK_PACKAGE_VENDOR "Unicode Consortium")
 set(CPACK_PACKAGE_CONTACT "https://github.com/unicode-org/inflection")


### PR DESCRIPTION
##  Ubuntu Packaging with CPack & GitHub Actions

This PR introduces a GitHub Actions workflow for building and packaging the Unicode Inflection library on Ubuntu using CPack. It generates `.deb` and `.tar.gz` artifacts and uploads them to GitHub Releases when a Git tag is pushed. ICU 77.1 is installed from a prebuilt binary release.

---

###  Key Changes

####   CMake / CPack Configuration
- Updates `CMakeLists.txt` to:
  - Dynamically parse version from Git tags (e.g. `Inflection-0.1.0`)
  - Configure CPack to generate `.deb` and `.tar.gz` artifacts

####  GitHub Actions Workflow
- Workflow file: `.github/workflows/create-ubuntu-distribution-packaging.yml`
- Triggered on tag push (e.g., `v0.1.0`)
- Key steps:
  - Installs ICU 77.1 from a prebuilt Ubuntu binary
  - Builds using Clang with CMake
  - Runs tests with `make check`
  - Packages using `cpack`
  - Uploads artifacts to GitHub Release

---

###  Outputs

-  Ubuntu `.deb` package
-  Source `.tar.gz` package
