### PR TITLE
issue 147 Fix the last 3 missing doc warning.

### DIFF
--- a/inflection/src/inflection/dialog/SemanticFeature.hpp
+++ b/inflection/src/inflection/dialog/SemanticFeature.hpp
@@ -72,6 +72,11 @@ public:
      * aliased without specifying the name.
      */
     virtual bool isAliased() const;
+    /**
+     * Checks if this name is less than the name of the other.
+     * @param other The semantic feature object to be compared with this.
+     * @return True if this name is less than the other, false otherwise.
+     */
     bool operator<(const SemanticFeature& other) const;
     /**
      * Returns true when both objects refer to the same semantic feature, with the same

--- a/inflection/src/inflection/lang/features/LanguageGrammarFeatures_GrammarCategory.hpp
+++ b/inflection/src/inflection/lang/features/LanguageGrammarFeatures_GrammarCategory.hpp
@@ -63,11 +63,16 @@ public:
     /**
      * Compares the name of this grammar category with the other..
      * @param other The grammar category object to be compared with this.
-     * @return the value 0 if the name of the argument other is equal to the name of this; a value -1 if the name 
+     * @return the value 0 if the name of the argument other is equal to the name of this; a value -1 if the name
      *         of this is lexicographically less than the name of the argument other; and a value 1 if the name
      *         of this is lexicographically greater than the name of the argument other.
      */
     virtual int32_t compareTo(const LanguageGrammarFeatures_GrammarCategory& other) const;
+    /**
+     * Checks if this name is less than the name of the other.
+     * @param other The grammar category object to be compared with this.
+     * @return True if the name is lexicographically less than the name of the argument other, false otherwise.
+     */
     bool operator<(const LanguageGrammarFeatures_GrammarCategory& other) const;
 
 

--- a/inflection/src/inflection/lang/features/LanguageGrammarFeatures_GrammarFeatures.hpp
+++ b/inflection/src/inflection/lang/features/LanguageGrammarFeatures_GrammarFeatures.hpp
@@ -45,6 +45,11 @@ public:
      *         of this is lexicographically greater than the name of the argument other.
      */
     virtual int32_t compareTo(const LanguageGrammarFeatures_GrammarFeatures& other) const;
+    /**
+     * Checks if this name is less than the name of the other.
+     * @param other The grammar features object to be compared with this.
+     * @return True if the name is lexicographically less than the name of the argument other, false otherwise.
+     */
     bool operator<(const LanguageGrammarFeatures_GrammarFeatures& other) const;
 
 protected: /* package */


### PR DESCRIPTION
We need to add these 3  in comments doc to address the last 3 warnings. We have problem to land <=> operator since it require C++20. So let's fix doxygen issue first and discuss the <=> operator separately.