### PR TITLE
Fix unaligned memory access in memory-mapped file loading

### DIFF
--- a/inflection/src/inflection/dictionary/DictionaryMetaData_MMappedDictionary.cpp
+++ b/inflection/src/inflection/dictionary/DictionaryMetaData_MMappedDictionary.cpp
@@ -21,7 +21,7 @@ DictionaryMetaData_MMappedDictionary::DictionaryMetaData_MMappedDictionary(const
 
 DictionaryMetaData_MMappedDictionary::DictionaryMetaData_MMappedDictionary(::inflection::util::MemoryMappedFile* memoryMappedRegion, const ::std::u16string& sourcePath)
     : options(npc(memoryMappedRegion)->read<int16_t>())
-    , locale(npc(memoryMappedRegion)->readArray<char>(MAX_LANGUAGE_CODE_LENGTH))
+    , locale(npc(memoryMappedRegion)->readArray<char>(MAX_LANGUAGE_CODE_LENGTH).data_ptr())
     , typesStringContainer(memoryMappedRegion)
     , bitsTypesSingletons(npc(memoryMappedRegion)->read<int8_t>())
     , bitsPropertyMapId(npc(memoryMappedRegion)->read<int8_t>())
@@ -209,7 +209,7 @@ DictionaryMetaData_MMappedDictionary* DictionaryMetaData_MMappedDictionary::crea
     }
 
     // Verify header starts with magic token
-    const char* magicMarker = npc(mappedRegion)->readArray<char>(sizeof(MAGIC_MARKER));
+    const char* magicMarker = npc(mappedRegion)->readArray<char>(sizeof(MAGIC_MARKER)).data_ptr();
     if (strncmp(magicMarker, MAGIC_MARKER, sizeof(MAGIC_MARKER)) != 0) {
         throw ::inflection::exception::IOException(u"Input file " + sourcePath + u" has invalid header");
     }

--- a/inflection/src/inflection/dictionary/DictionaryMetaData_MMappedDictionary.hpp
+++ b/inflection/src/inflection/dictionary/DictionaryMetaData_MMappedDictionary.hpp
@@ -70,7 +70,7 @@ private:
     int8_t bitsPropertyValueMapValuesSize {  };
     int32_t wordsToTypesSingletonsSize {  };
     ::inflection::dictionary::metadata::MarisaTrie<uint64_t> wordsToDataTrie {::std::map<std::u16string_view, uint64_t>()};
-    const int64_t* const wordsToTypesSingletons {  };
+    inflection::util::MemoryMappedFile::UnalignedArray<int64_t> wordsToTypesSingletons;
     ::inflection::dictionary::metadata::CompressedArray<uint64_t> wordsToDataSingletons {::std::vector<uint64_t>()};
     ::inflection::dictionary::metadata::StringArrayContainer propertyNameToKeyId {  };
     ::inflection::dictionary::metadata::StringContainer propertyValuesStringContainer {  };

--- a/inflection/src/inflection/dictionary/Inflector_InflectionPattern.cpp
+++ b/inflection/src/inflection/dictionary/Inflector_InflectionPattern.cpp
@@ -51,7 +51,7 @@ Inflector_Inflection inflection::dictionary::Inflector_InflectionPattern::getInf
     return {
         *this,
         int32_t(suffixIdx),
-        *(inflectorDictionary.grammemePatterns + grammemesIdx)
+        inflectorDictionary.grammemePatterns[grammemesIdx]
     };
 }
 

--- a/inflection/src/inflection/dictionary/Inflector_MMappedDictionary.hpp
+++ b/inflection/src/inflection/dictionary/Inflector_MMappedDictionary.hpp
@@ -43,7 +43,7 @@ private:
     const inflection::util::ULocale locale;
 
     int32_t grammemePatternsSize {  };
-    const int64_t *grammemePatterns {  };
+    inflection::util::MemoryMappedFile::UnalignedArray<int64_t> grammemePatterns;
 
     // inflectionPatterns - originally a std::map<std::u16string, Inflector_InflectionPattern>
     inflection::dictionary::metadata::StringContainer inflectionSuffixes;
@@ -55,7 +55,7 @@ private:
     int8_t numBitsForSuffixToIdentifierRunsIdx {  };
     int8_t numBitsForSuffixToIdentifierRunsLen {  };
     int32_t frequencyArraySize {  };
-    const int32_t *frequenciesArray {  };
+    inflection::util::MemoryMappedFile::UnalignedArray<int32_t> frequenciesArray;
     inflection::dictionary::metadata::MarisaTrie<int32_t> identifierToInflectionPatternTrie;
 
     /** suffixPatterns - originally a std::map<std::u16string, ::std::map<Inflector_Suffix, ::std::u16string>> */

--- a/inflection/src/inflection/dictionary/metadata/CompressedArray.hpp
+++ b/inflection/src/inflection/dictionary/metadata/CompressedArray.hpp
@@ -37,7 +37,8 @@ public:
 private:
     int32_t dataArrayLength {  };
     int32_t wordWidth {  };
-    uint64_t* data {  };
+    uint64_t* data_owned {  };
+    inflection::util::MemoryMappedFile::UnalignedArray<uint64_t> data;
     uint64_t selectMask {  };
     bool ownData {  };
 
@@ -51,7 +52,7 @@ inflection::dictionary::metadata::CompressedArray<T>::CompressedArray(::inflecti
 {
     npc(mappedFile)->read(&dataArrayLength);
     mappedFile->read(&wordWidth);
-    mappedFile->read(&data, sizeof(data[0]) * dataArrayLength);
+    data = mappedFile->readArray<uint64_t>(dataArrayLength);
     selectMask = ((uint64_t(1) << wordWidth) - 1);
 }
 
@@ -60,11 +61,12 @@ template<typename T>
 inflection::dictionary::metadata::CompressedArray<T>::CompressedArray(int32_t wordWidth, int32_t arraySize)
     : dataArrayLength(((arraySize * wordWidth)+DATAWIDTH-1)/DATAWIDTH)
     , wordWidth(wordWidth)
-    , data(new uint64_t[dataArrayLength])
+    , data_owned(new uint64_t[dataArrayLength])
+    , data(reinterpret_cast<char*>(data_owned), dataArrayLength)
     , selectMask((uint64_t(1) << wordWidth) - 1)
     , ownData(true)
 {
-    memset(data, 0, dataArrayLength * sizeof(data[0]));
+    memset(data_owned, 0, dataArrayLength * sizeof(data_owned[0]));
 }
 
 template<typename T>
@@ -113,7 +115,7 @@ inflection::dictionary::metadata::CompressedArray<T>::CompressedArray(const ::st
 template<typename T>
 inflection::dictionary::metadata::CompressedArray<T>::~CompressedArray() {
     if (ownData) {
-        delete[] data;
+        delete[] data_owned;
     }
 }
 
@@ -127,16 +129,16 @@ template <typename T>
 T inflection::dictionary::metadata::CompressedArray<T>::read(int32_t index) const{
     int32_t startBitPos = index * wordWidth;
     int32_t shiftStart = startBitPos % DATAWIDTH;
-    auto currData = data + (startBitPos / DATAWIDTH);
-    auto endData = data + ((startBitPos + (wordWidth - 1)) / DATAWIDTH);
+    int32_t currIdx = startBitPos / DATAWIDTH;
+    int32_t endIdx = (startBitPos + (wordWidth - 1)) / DATAWIDTH;
 
-    if (index < 0 || endData > data + dataArrayLength) {
+    if (index < 0 || endIdx >= dataArrayLength) {
         throw inflection::exception::IndexOutOfBoundsException(u"Invalid CompressedArray index");
     }
 
-    uint64_t retVal = (selectMask & (*currData >> shiftStart));
-    if (currData++ != endData) {
-        retVal |= (selectMask & (*currData << (DATAWIDTH - shiftStart)));
+    uint64_t retVal = (selectMask & (data[currIdx] >> shiftStart));
+    if (currIdx != endIdx) {
+        retVal |= (selectMask & (data[endIdx] << (DATAWIDTH - shiftStart)));
     }
     return ((T) retVal);
 }
@@ -147,10 +149,10 @@ void inflection::dictionary::metadata::CompressedArray<T>::write(int32_t index, 
 
     int32_t startBitPos = index * wordWidth;
     int32_t shiftStart = startBitPos % DATAWIDTH;
-    auto currData = data + (startBitPos / DATAWIDTH);
-    auto endData = data + ((startBitPos + (wordWidth - 1)) / DATAWIDTH);
+    auto currData = data_owned + (startBitPos / DATAWIDTH);
+    auto endData = data_owned + ((startBitPos + (wordWidth - 1)) / DATAWIDTH);
 
-    if (endData > data + dataArrayLength) {
+    if (endData > data_owned + dataArrayLength) {
         throw inflection::exception::IndexOutOfBoundsException(u"CompressedArray index too big");
     }
 
@@ -165,5 +167,5 @@ void inflection::dictionary::metadata::CompressedArray<T>::serialize(::std::ostr
 {
     writer.write(reinterpret_cast<const char*>(&dataArrayLength), sizeof(dataArrayLength));
     writer.write(reinterpret_cast<const char*>(&wordWidth), sizeof(wordWidth));
-    writer.write(reinterpret_cast<const char*>(data), sizeof(data[0]) * dataArrayLength);
+    writer.write(reinterpret_cast<const char*>(data.data_ptr()), sizeof(uint64_t) * dataArrayLength);
 }

--- a/inflection/src/inflection/dictionary/metadata/MarisaTrie.hpp
+++ b/inflection/src/inflection/dictionary/metadata/MarisaTrie.hpp
@@ -125,7 +125,7 @@ inflection::dictionary::metadata::MarisaTrie<T>::MarisaTrie(::inflection::util::
     , encodingEnum(encodingEnum)
 {
     if (trieSize > 0) {
-        const char* rawTrieData = npc(mappedFile)->readArray<char>(trieSize);
+        const char* rawTrieData = npc(mappedFile)->readArray<char>(trieSize).data_ptr();
         trie.map(rawTrieData, trieSize);
     }
     else {

--- a/inflection/src/inflection/dictionary/metadata/StringArrayContainer.cpp
+++ b/inflection/src/inflection/dictionary/metadata/StringArrayContainer.cpp
@@ -23,7 +23,8 @@ inflection::dictionary::metadata::StringArrayContainer::StringArrayContainer(::i
 
 inflection::dictionary::metadata::StringArrayContainer::StringArrayContainer(const ::std::set<::std::u16string_view>& strings, ::std::map<::std::u16string_view, int32_t>* mappingResult)
     : arraySize(int32_t(strings.size()))
-    , stringIndexesWithLen(new int32_t[arraySize])
+    , stringIndexesWithLen_owned(new int32_t[arraySize])
+    , stringIndexesWithLen(reinterpret_cast<char*>(stringIndexesWithLen_owned), arraySize)
 {
     if (!npc(mappingResult)->empty()) {
         throw ::inflection::exception::IllegalArgumentException(u"The mapping result should be empty");
@@ -40,7 +41,7 @@ inflection::dictionary::metadata::StringArrayContainer::StringArrayContainer(con
         if (len > LENGTH_MASK || ((offset << LENGTH_BITS) >> LENGTH_BITS) != offset) {
             throw ::inflection::exception::IllegalArgumentException(u"String is too large: " + std::u16string(string));
         }
-        stringIndexesWithLen[stringIndexesIdx] = (offset << LENGTH_BITS) | len;
+        stringIndexesWithLen_owned[stringIndexesIdx] = (offset << LENGTH_BITS) | len;
         allStringsBuffer.append(string);
         allStringsBuffer.push_back(0); // null terminate
         npc(mappingResult)->emplace(string, stringIndexesIdx);
@@ -52,8 +53,9 @@ inflection::dictionary::metadata::StringArrayContainer::StringArrayContainer(con
     allStringsBuffer.append(paddingSize, 0);
 
     allStringsSize = (int32_t)allStringsBuffer.length();
-    allStrings = new char16_t[allStringsSize];
-    memcpy(allStrings, allStringsBuffer.data(), allStringsSize * sizeof(allStrings[0]));
+    allStrings_owned = new char16_t[allStringsSize];
+    allStrings = inflection::util::MemoryMappedFile::UnalignedArray<char16_t>(reinterpret_cast<char*>(allStrings_owned), allStringsSize);
+    memcpy(allStrings_owned, allStringsBuffer.data(), allStringsSize * sizeof(char16_t));
     ownData = true;
 }
 
@@ -65,8 +67,8 @@ inflection::dictionary::metadata::StringArrayContainer::StringArrayContainer()
 inflection::dictionary::metadata::StringArrayContainer::~StringArrayContainer()
 {
     if (ownData) {
-        delete[] stringIndexesWithLen;
-        delete[] allStrings;
+        delete[] stringIndexesWithLen_owned;
+        delete[] allStrings_owned;
     }
 }
 
@@ -75,8 +77,8 @@ void inflection::dictionary::metadata::StringArrayContainer::write(::std::ostrea
     output.write(reinterpret_cast<const char*>(&arraySize), sizeof(arraySize));
     output.write(reinterpret_cast<const char*>(&allStringsSize), sizeof(allStringsSize));
 
-    output.write(reinterpret_cast<const char*>(stringIndexesWithLen), arraySize * sizeof(stringIndexesWithLen[0]));
-    output.write(reinterpret_cast<const char*>(allStrings), allStringsSize * sizeof(allStrings[0]));
+    output.write(reinterpret_cast<const char*>(stringIndexesWithLen.data_ptr()), arraySize * sizeof(int32_t));
+    output.write(reinterpret_cast<const char*>(allStrings.data_ptr()), allStringsSize * sizeof(char16_t));
 }
 
 ::std::u16string inflection::dictionary::metadata::StringArrayContainer::getString(int32_t offset) const
@@ -87,7 +89,7 @@ void inflection::dictionary::metadata::StringArrayContainer::write(::std::ostrea
     int32_t value = stringIndexesWithLen[offset];
     int32_t len = value & LENGTH_MASK;
     int32_t stringStart = value >> LENGTH_BITS;
-    return std::u16string(allStrings + stringStart, len);
+    return std::u16string(allStrings.data_ptr() + stringStart, len);
 }
 
 int32_t inflection::dictionary::metadata::StringArrayContainer::getIdentifierIfAvailable(::std::u16string_view string) const
@@ -101,7 +103,7 @@ int32_t inflection::dictionary::metadata::StringArrayContainer::getIdentifierIfA
         int32_t len = value & LENGTH_MASK;
         int32_t stringStart = uint32_t(value) >> LENGTH_BITS;
 
-        std::u16string_view strToCompare(allStrings + stringStart, len);
+        std::u16string_view strToCompare(allStrings.data_ptr() + stringStart, len);
 
         auto comp = string.compare(strToCompare);
         if (comp < 0) {

--- a/inflection/src/inflection/dictionary/metadata/StringArrayContainer.hpp
+++ b/inflection/src/inflection/dictionary/metadata/StringArrayContainer.hpp
@@ -18,8 +18,10 @@ class INFLECTION_INTERNAL_API inflection::dictionary::metadata::StringArrayConta
 private:
     int32_t arraySize {  };
     int32_t allStringsSize {  };
-    int32_t* stringIndexesWithLen {  };
-    char16_t* allStrings {  };
+    int32_t* stringIndexesWithLen_owned {  };
+    char16_t* allStrings_owned {  };
+    inflection::util::MemoryMappedFile::UnalignedArray<int32_t> stringIndexesWithLen {  };
+    inflection::util::MemoryMappedFile::UnalignedArray<char16_t> allStrings {  };
     bool ownData {  };
 
 public:

--- a/inflection/src/inflection/dictionary/metadata/StringContainer.cpp
+++ b/inflection/src/inflection/dictionary/metadata/StringContainer.cpp
@@ -26,9 +26,7 @@ StringContainer::StringContainer(::inflection::util::MemoryMappedFile *mappedFil
     mappedFile->read(&trieSize);
     if (trieSize > 0) {
         // non-empty trie to read.
-        char* rawTrieData;
-        mappedFile->read(&rawTrieData, trieSize);
-
+        const char* rawTrieData = mappedFile->readArray<char>(trieSize).data_ptr();
         trie.map(rawTrieData, trieSize);
         _size = (int32_t) trie.num_keys();
     }

--- a/inflection/src/inflection/tokenizer/trie/SerializedTrie.cpp
+++ b/inflection/src/inflection/tokenizer/trie/SerializedTrie.cpp
@@ -27,8 +27,7 @@ SerializedTrie::~SerializedTrie()
 ::inflection::util::MemoryMappedFile& SerializedTrie::validateHeader(::inflection::util::MemoryMappedFile& mappedFile, const std::u16string &corpusFile)
 {
     // Verify header starts with magic token
-    const char* magicMarker;
-    mappedFile.read(&magicMarker, MAGIC_MARKER_LEN);
+    const char* magicMarker = mappedFile.readArray<char>(MAGIC_MARKER_LEN).data_ptr();
     if (strncmp(magicMarker, MAGIC_MARKER, MAGIC_MARKER_LEN) != 0) {
         throw ::inflection::exception::IOException(u"Input file " + corpusFile + u" has an invalid header");
     }

--- a/inflection/src/inflection/util/MemoryMappedFile.hpp
+++ b/inflection/src/inflection/util/MemoryMappedFile.hpp
@@ -6,6 +6,7 @@
 #include <inflection/util/fwd.hpp>
 #include <inflection/exception/IOException.hpp>
 #include <inflection/util/StringUtils.hpp>
+#include <cstring>
 
 // RAII wrapper
 class INFLECTION_INTERNAL_API inflection::util::MemoryMappedFile final
@@ -29,14 +30,12 @@ private:
     template <typename X>
     static void readFromCursor(char* readCursorWrapper, X* out)
     {
-        *out = *((X*) readCursorWrapper);
+        ::std::memcpy(out, readCursorWrapper, sizeof(X));
     }
 
+    // Disallow returning raw pointers to unaligned data
     template <typename X>
-    static void readFromCursor(char* readCursorWrapper, X** out)
-    {
-        *out = (X*) readCursorWrapper;
-    }
+    static void readFromCursor(char* readCursorWrapper, X** out) = delete;
 
 public:
     template <typename X>
@@ -51,12 +50,32 @@ public:
         offset += toRead;
     }
 
+public:
     template <typename X>
-    X* readArray(size_t length)
+    class UnalignedArray {
+        char* data;
+        size_t length;
+    public:
+        UnalignedArray(char* d, size_t l) : data(d), length(l) {}
+        UnalignedArray() : data(nullptr), length(0) {}
+        X operator[](size_t idx) const {
+            X val;
+            ::std::memcpy(&val, data + idx * sizeof(X), sizeof(X));
+            return val;
+        }
+        size_t size() const { return length; }
+        const X* data_ptr() const { return reinterpret_cast<const X*>(data); }
+    };
+
+    template <typename X>
+    UnalignedArray<X> readArray(size_t length)
     {
-        X* out = nullptr;
-        read(&out, sizeof(*out)*length);
-        return out;
+        if ((size - offset) < sizeof(X) * length) {
+            throw inflection::exception::IOException(u"Input too small for array");
+        }
+        char* cursor = data + offset;
+        offset += sizeof(X) * length;
+        return UnalignedArray<X>(cursor, length);
     }
 
     template <typename X>


### PR DESCRIPTION
This Pull Request addresses crashes (such as SIGILL / Illegal Instruction) caused by unaligned memory access when loading and reading data from memory-mapped files.

## This is a temporary fix, to unblock integration on some platforms. The long term solution is going to adopt structure alignment approach.

The Problem
The current implementation performs direct pointer casting (e.g., _((X_) readCursor)) on data read from memory-mapped files. This assumes that the data in the file is always perfectly aligned to the natural alignment requirements of type X (e.g., 8-byte alignment for int64_t). 

However, binary dictionary files may not always have the necessary padding to guarantee this alignment at every offset. On architectures that strictly enforce data alignment, or when compiler optimizations (such as those utilizing AVX instructions) assume correct alignment, dereferencing these unaligned pointers leads to undefined behavior and runtime crashes.

The Solution
This PR introduces a safer approach that maintains the performance benefits of memory mapping without risking unaligned access crashes:

1.  Safe Primitive Reads: Replaced direct pointer casting with std::memcpy in MemoryMappedFile::readFromCursor. Modern compilers optimize this into efficient single-instruction loads on most platforms, ensuring safety without performance penalty.
2.  UnalignedArray Wrapper: Introduced a lightweight UnalignedArray<X> wrapper to handle array access. It provides an operator[] that safely extracts elements using memcpy, avoiding raw pointer dereference on potentially unaligned addresses in the mapped file.
3.  Refactored Dependents: Updated internal structures like StringArrayContainer and CompressedArray to use this wrapper instead of raw pointers for mapped data.

All unit tests have been verified to pass successfully after these changes.