### PR TITLE
fix stable sort

### DIFF
--- a/inflection/src/inflection/dialog/DictionaryLookupInflector.cpp
+++ b/inflection/src/inflection/dialog/DictionaryLookupInflector.cpp
@@ -89,7 +89,7 @@ inline void traceLogSortedInflectionGrammemes(const ::std::vector<::inflection::
             return DictionaryLookupInflector::compareInflectionGrammemes(inflection1, inflection2, disambiguationGrammemes) < 0;
         };
 
-        std::ranges::sort(inflectionGrammemes, inflectionComparator);
+        std::ranges::stable_sort(inflectionGrammemes, inflectionComparator);
         if (LoggerConfig::isTraceEnabled()) {
             traceLogSortedInflectionGrammemes(inflectionGrammemes, dictionary);
         }


### PR DESCRIPTION
_Why stable_sort is better than sort in this case_

The `DictionaryLookupInflector` is responsible for selecting the best inflection candidate for a given word based on a set of constraints. It retrieves potential candidates and sorts them using a comparator that computes a match score.

However, it is common for multiple candidate inflections to have identical match scores. For example, in Hebrew, a single unpointed stem can often correspond to both a past tense verb and an imperative verb with the same gender and number features, yielding an equal match score if those specific features are not part of the disambiguation constraints.

Previously, the code used `std::ranges::sort`, which is an _unstable_ sort. This means that when two candidates have the same score, their relative order in the output is unspecified and non-deterministic. In practice, this led to flaky test failures where the "correct" candidate (as expected by the test suite) would sometimes be selected and sometimes not, depending on the arbitrary order returned by the sort algorithm.

By switching to `std::ranges::stable_sort`, we preserve the relative order of candidate inflections that compare equal. This makes the selection process deterministic and consistent across different runs and environments, effectively resolving the flaky test failures observed in the Hebrew test suite while maintaining the existing prioritization logic.

Another failing example is 'yen' -> 'yens'.

I've checked other reasons for this to happen and this seems like the best answer (I checked different versions of marisa tree, and ICU and nothing mattered).