### PR TITLE
Avoid class template argument deduction (CTAD) to fix warnings

### DIFF
--- a/inflection/src/inflection/dialog/CommonConceptFactoryImpl.cpp
+++ b/inflection/src/inflection/dialog/CommonConceptFactoryImpl.cpp
@@ -47,9 +47,10 @@ static std::pair<SpeakableString, SpeakableString> getDefaultList(const ::inflec
 
     UErrorCode status = U_ZERO_ERROR;
     UListFormatter* listFmt = ulistfmt_openForType(language.getName().c_str(), type, ULISTFMT_WIDTH_WIDE, &status);
-    ::inflection::util::Finally finally([listFmt]() noexcept {
+    auto cleanup = [listFmt]() noexcept {
         ulistfmt_close(listFmt);
-    });
+    };
+    ::inflection::util::Finally<decltype(cleanup)> finally(cleanup);
     ::inflection::exception::ICUException::throwOnFailure(status);
     auto listSize = ulistfmt_format(listFmt, reinterpret_cast<const UChar *const *>(twoItems ? list2Items : listItems), nullptr, twoItems ? list2ItemsSize : listItemsSize,
                     (UChar *)&(formatResult[0]), int32_t(formatResult.length()), &status);
@@ -83,9 +84,10 @@ CommonConceptFactoryImpl::CommonConceptFactoryImpl(const ::inflection::util::ULo
 {
     auto status = U_ZERO_ERROR;
     auto localeData = ulocdata_open(language.getName().c_str(), &status);
-    ::inflection::util::Finally finally([localeData]() noexcept {
+    auto cleanup = [localeData]() noexcept {
         ulocdata_close(localeData);
-    });
+    };
+    ::inflection::util::Finally<decltype(cleanup)> finally(cleanup);
     ::inflection::exception::ICUException::throwOnFailure(status);
     startQuote = getQuote(localeData, ULOCDATA_QUOTATION_START);
     endQuote = getQuote(localeData, ULOCDATA_QUOTATION_END);

--- a/inflection/tools/buildDictionary/InflectionDictionary.cpp
+++ b/inflection/tools/buildDictionary/InflectionDictionary.cpp
@@ -381,12 +381,13 @@ Inflector_InflectionDictionary* InflectionDictionary::readXML(const ::inflection
 
     xmlDocPtr xmlDoc = nullptr;
     {
-        ::inflection::util::Finally finally([&xmlDoc]() noexcept {
+        auto cleanup = [&xmlDoc]() noexcept {
             if (xmlDoc != nullptr) {
                 xmlFreeDoc(xmlDoc);
             }
             xmlCleanupParser();
-        });
+        };
+        ::inflection::util::Finally<decltype(cleanup)> finally(cleanup);
         ::std::u16string resourceName = inflection::util::StringUtils::to_u16string(source);
         ::inflection::util::MemoryMappedFile mMapFile(resourceName);
         xmlDoc = xmlParseMemory(mMapFile.getData(), int32_t(mMapFile.getSize()));

--- a/inflection/tools/buildTokDictionary/buildTokDictionary.cpp
+++ b/inflection/tools/buildTokDictionary/buildTokDictionary.cpp
@@ -135,7 +135,7 @@ int main(int argc, const char * const argv[]) {
     }
 
     if (errorCount == 0) {
-        ::inflection::dictionary::metadata::MarisaTrie trie(stringToIntegerMap);
+        ::inflection::dictionary::metadata::MarisaTrie<int32_t> trie(stringToIntegerMap);
         out.write(inflection::tokenizer::trie::SerializedTrie::MAGIC_MARKER, sizeof(inflection::tokenizer::trie::SerializedTrie::MAGIC_MARKER));
         out.write(reinterpret_cast<const char*>(&inflection::tokenizer::trie::SerializedTrie::VERSION), sizeof(inflection::tokenizer::trie::SerializedTrie::VERSION));
         out.write(reinterpret_cast<const char*>(&ENDIANNESS_MARKER), sizeof(ENDIANNESS_MARKER));


### PR DESCRIPTION
_Description_
This PR avoids using Class Template Argument Deduction (CTAD) for `inflection::util::Finally` and `inflection::dictionary::metadata::MarisaTrie` by explicitly specifying template arguments or using `decltype` for lambdas.

_Motivation_
In some environments (e.g. with strict warning flags like `-Wctad-maybe-unsupported` enabled), using CTAD without explicit deduction guides can trigger compiler warnings or errors. 

Instead of adding deduction guides to the headers, this PR changes the local invocations to avoid deduction entirely, making the code more robust across different compiler configurations and avoiding the need for deduction guides.