### PR TITLE
Inflection-0 Rename macOS release artifact package name from Darwin to macOS

### DIFF
--- a/.github/workflows/create-distribution-packaging.yml
+++ b/.github/workflows/create-distribution-packaging.yml
@@ -109,6 +109,7 @@ jobs:
           cd inflection/build
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCPACK_SYSTEM_NAME=macOS \
             -DICU_ROOT="$ICU_PREFIX" \
             -DCMAKE_PREFIX_PATH="$ICU_PREFIX;$XML2_PREFIX"
           make -j$(sysctl -n hw.ncpu)


### PR DESCRIPTION
Sets -DCPACK_SYSTEM_NAME=macOS during CMake configuration for macOS builds so CPack generates unicode-inflection-*-macOS.tar.gz instead of Darwin.